### PR TITLE
Fixes a bug in semantic versioning.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ A Gradle plugin for automatically generating versions from git tags and commits.
 
 ## Usage
 1. Add the plugin to your build.gradle as shown [here](https://plugins.gradle.org/plugin/com.zoltu.gradle.plugin.git-versioning).
-2. Tag your repository (anywhere in history) with a tag named like `v1.2`.
+2. Tag your repository (anywhere in history) with a tag named like `v1.2` or a semantic version tag like `v1.2.3-tag1.tag2` or something in between like `v1.2-tag1.tag2`
 3. Remove the `version` property from your `build.gradle` file.
 
 ## How it Works
-When you run gradle, it uses jGit to execute `git describe --long` (technically: `git.describe().setLong(true).call)`) to create a string containing the nearest tag looking like `v1.2`, the number of commits since that tag, and the short sha.  The plugin then splits that apart and sets the project version to `{major}.{minor}.{count}`.  It also sets the version in the jar manifest (if you are building a JAR):
-* `Implementation-Version`: `{major}.{minor}.{count}`
+When you run gradle, it uses jGit to execute `git describe --long` (technically: `git.describe().setLong(true).call)`) to create a string containing the nearest tag looking like `v1.2`, the number of commits since that tag, and the short sha.  The plugin then splits that apart and sets the project version to `{major}.{minor}.{count}` or `{major}.{minor}.{patch}-{tags}.{count}` or `{major}.{minor}.{count}-{tags}` (depending on what your git tag looks like).  It also sets the version in the jar manifest (if you are building a JAR):
+* `Implementation-Version`: `{major}.{minor}.{count}` or `{major}.{minor}.{patch}-{tags}.{count}` or `{major}.{minor}.{count}-{tags}`
 * `Implementation-Sha`: `{sha}`
 * `Specification-Version`: `{major}.{minor}`

--- a/src/main/kotlin/com/zoltu/gradle/plugin/GitVersioning.kt
+++ b/src/main/kotlin/com/zoltu/gradle/plugin/GitVersioning.kt
@@ -23,13 +23,14 @@ class GitVersioning : Plugin<Project> {
 	}
 
 	private fun getSimpleVersionInfo(describeResults: String): VersionInfo {
-		val regex = Regex("""v([0-9]+?)\.([0-9]+?)\-([0-9]+?)\-g(.*)""")
+		val regex = Regex("""v([0-9]+?)\.([0-9]+?)(?:\-([0-9A-Za-z\.\-]+))?\-([0-9]+?)\-g(.*)""")
 		val match = regex.matchEntire(describeResults) ?: throw Exception("Git describe didn't return the expected format.")
 		val major = match.groups[1]?.value ?: throw Exception("Git describe matched the expected format but the matcher didn't return group 1.")
 		val minor = match.groups[2]?.value ?: throw Exception("Git describe matched the expected format but the matcher didn't return group 2.")
-		val commitCount = match.groups[3]?.value ?: throw Exception("Git describe matched the expected format but the matcher didn't return group 3.")
-		val sha = match.groups[4]?.value ?: throw Exception("Git describe matched the expected format but the matcher didn't return group 4.")
-		return VersionInfo(major = major, minor = minor, commitCount = commitCount, sha = sha)
+		val tags = match.groups[3]?.value
+		val commitCount = match.groups[4]?.value ?: throw Exception("Git describe matched the expected format but the matcher didn't return group 3.")
+		val sha = match.groups[5]?.value ?: throw Exception("Git describe matched the expected format but the matcher didn't return group 4.")
+		return VersionInfo(major = major, minor = minor, commitCount = commitCount, sha = sha, tags = tags)
 	}
 
 	private fun tryGetSemanticVersionInfo(describeResults: String): VersionInfo? {

--- a/src/main/kotlin/com/zoltu/gradle/plugin/VersionInfo.kt
+++ b/src/main/kotlin/com/zoltu/gradle/plugin/VersionInfo.kt
@@ -2,6 +2,19 @@ package com.zoltu.gradle.plugin
 
 class VersionInfo(val major: String, val minor: String, val commitCount: String, val sha: String, val patch: String? = null, val tags: String? = null) {
 	override fun toString(): String {
-		return "$major.$minor.${patch ?: commitCount}${if (tags != null) "-$tags" else ""}${if (patch != null) "-$commitCount" else ""}".toString()
+		val suffix = if (tags != null && patch != null) {
+			// semantic versioning
+			"$patch-$tags.$commitCount"
+		} else if (patch != null) {
+			// semantic versioning
+			"$patch-$commitCount"
+		} else if (tags != null) {
+			// simple versioning
+			"$commitCount-$tags"
+		} else {
+			// simple versioning
+			"$commitCount"
+		}
+		return "$major.$minor.$suffix".toString()
 	}
 }

--- a/src/test/kotlin/Tests.kt
+++ b/src/test/kotlin/Tests.kt
@@ -19,7 +19,7 @@ class Tests : Spek() {
 					assertEquals("2", versionInfo.commitCount)
 					assertEquals("8885517", versionInfo.sha)
 					assertEquals("beta-4.5", versionInfo.tags)
-					assertEquals("1.2.3-beta-4.5-2", versionInfo.toString())
+					assertEquals("1.2.3-beta-4.5.2", versionInfo.toString())
 				}
 			}
 		}
@@ -39,6 +39,25 @@ class Tests : Spek() {
 					assertEquals("abcd1234", versionInfo.sha)
 					assertEquals(null, versionInfo.tags)
 					assertEquals("1.2.3-5", versionInfo.toString())
+				}
+			}
+		}
+
+		given("a simple version with tags describe result") {
+			val describeResult = "v1.2-tag-1.tag2.4-3-gabcd1234"
+			on("tryGetSemanticVersionInfo") {
+
+				val versionInfo = GitVersioning().getVersionInfo(describeResult)
+
+				it("parses into expected VersionInfo") {
+					assertNotNull(versionInfo)
+					assertEquals("1", versionInfo.major)
+					assertEquals("2", versionInfo.minor)
+					assertEquals(null, versionInfo.patch)
+					assertEquals("3", versionInfo.commitCount)
+					assertEquals("abcd1234", versionInfo.sha)
+					assertEquals("tag-1.tag2.4", versionInfo.tags)
+					assertEquals("1.2.3-tag-1.tag2.4", versionInfo.toString())
 				}
 			}
 		}


### PR DESCRIPTION
My implementation didn't align with semantic versioning spec.

Also added support for tags in simple versions.

Also updated readme.

Bumps major version because behavior differs from previous version (which was broken).  See https://xkcd.com/1172/ for details on why fixing a bug requires a major version bump.
