### PR TITLE
Fixes bug that caused gradle to be unable to instantiate the extension.

### DIFF
--- a/src/main/kotlin/com/zoltu/gradle/plugin/GitVersioning.kt
+++ b/src/main/kotlin/com/zoltu/gradle/plugin/GitVersioning.kt
@@ -80,5 +80,5 @@ class GitVersioning : Plugin<Project> {
 		project.extensions.create("ZoltuGitVersioning", Extension::class.java, versionInfo)
 	}
 
-	data class Extension(val versionInfo: VersionInfo)
+	open class Extension(open val versionInfo: VersionInfo)
 }

--- a/src/test/kotlin/Tests.kt
+++ b/src/test/kotlin/Tests.kt
@@ -1,4 +1,5 @@
 import com.zoltu.gradle.plugin.GitVersioning
+import org.gradle.testfixtures.ProjectBuilder
 import org.jetbrains.spek.api.Spek
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -79,4 +80,17 @@ class Tests : Spek({
 			}
 		}
 	}
+
+	// unfortunately, this test fails unless you swap out the call to `getGitDescribeResults(project.rootDir)` with `"v2.0-23-gee473b7"` because the test doesn't have a git directory in its path hierarchy
+//	given("a project") {
+//		val project = ProjectBuilder.builder().build()
+//
+//		on("applying the plugin") {
+//			project.pluginManager.apply(GitVersioning::class.java)
+//
+//			it("has access to the extension") {
+//				assertNotNull(project.extensions.getByName("ZoltuGitVersioning") as GitVersioning.Extension)
+//			}
+//		}
+//	}
 }) {}


### PR DESCRIPTION
Unfortunately, the way Gradle does plugin extensions is by extending the extension, which means it has to be open.

Adds a test that allows for easily testing this sort of thing in the future, though I don't know how to easily make it work against the real thing.

Second attempt at fixing #16.
