### PR TITLE
Generalize Regular Expression

### DIFF
--- a/src/main/kotlin/com/zoltu/gradle/plugin/GitVersioning.kt
+++ b/src/main/kotlin/com/zoltu/gradle/plugin/GitVersioning.kt
@@ -10,8 +10,8 @@ import java.io.File
 
 class GitVersioning : Plugin<Project> {
 	companion object {
-		val regexSimpleVersionInfo = Regex("""v([0-9]+?)\.([0-9]+?)(?:\-([0-9A-Za-z\.\-]+))?\-([0-9]+?)\-g(.*)""")
-		val regexSemanticVersionInfo = Regex("""v([0-9]+?)\.([0-9]+?)\.([0-9]+?)(?:\-([0-9A-Za-z\.\-]+))?\-([0-9]+?)\-g([a-zA-Z0-9]+?)""")
+		val regexSimpleVersionInfo = Regex("""[v]?([0-9]+?)\.([0-9]+?)(?:\-([0-9A-Za-z\.\-]+))?\-([0-9]+?)\-g(.*)""")
+		val regexSemanticVersionInfo = Regex("""[v]?([0-9]+?)\.([0-9]+?)\.([0-9]+?)(?:\-([0-9A-Za-z\.\-]+))?\-([0-9]+?)\-g([a-zA-Z0-9]+?)""")
 	}
 
 	override fun apply(project: Project?) {

--- a/src/test/kotlin/Tests.kt
+++ b/src/test/kotlin/Tests.kt
@@ -80,6 +80,25 @@ class Tests : Spek({
 			}
 		}
 	}
+	
+	given("a simple version without leading 'v' character result") {
+		val describeResult = "1.3.1-2-g35965aa"
+		on("tryGetSemanticVersionInfo") {
+			
+			val versionInfo = GitVersioning().getVersionInfo(describeResult)
+			
+			it("parses into expected VersionInfo") {
+				assertNotNull(versionInfo)
+				assertEquals("1", versionInfo.major)
+				assertEquals("3", versionInfo.minor)
+				assertEquals("1", versionInfo.patch)
+				assertEquals("2", versionInfo.commitCount)
+				assertEquals("35965aa", versionInfo.sha)
+				assertEquals(null, versionInfo.tags)
+				assertEquals("1.3.1-2", versionInfo.toString())
+			}
+		}
+	}
 
 	// unfortunately, this test fails unless you swap out the call to `getGitDescribeResults(project.rootDir)` with `"v2.0-23-gee473b7"` because the test doesn't have a git directory in its path hierarchy
 //	given("a project") {


### PR DESCRIPTION
My use case has tags which follow a slightly different pattern (e.g. '1.0.0' instead of 'v1.0.0') which the plugin does not currently support.

This PR alters the regular expressions used to process the output of git describe to accept output without a leading 'v' character.
