### PR TITLE
Adds support for light (non-annotated) tags.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ repositories {
 
 dependencies {
 	compile(group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib', version: '1.0.5')
-	compile(group: 'org.eclipse.jgit', name: 'org.eclipse.jgit', version: '4.5.0.201609210915-r')
+	compile(group: 'org.eclipse.jgit', name: 'org.eclipse.jgit', version: '6.2.0.202206071550-r')
 
 	testCompile(group: 'junit', name: 'junit', version: '4.12')
 }

--- a/src/main/kotlin/com/zoltu/gradle/plugin/GitVersioning.kt
+++ b/src/main/kotlin/com/zoltu/gradle/plugin/GitVersioning.kt
@@ -65,7 +65,7 @@ class GitVersioning : Plugin<Project> {
 				.build()!!
 		val git = Git.wrap(repository)!!
 		if (git.repository.allRefs.count() == 0) throw Exception("Your repository must have at least one commit in the repository for git-versioning to work.  Recommended solution: git commit")
-		return git.describe().setLong(true).call() ?: throw Exception("Your repository must have at least one tag in it for git-versioning to work.  Recommended solution: git tag v0.0")
+		return git.describe().setLong(true).setTags(true).call() ?: throw Exception("Your repository must have at least one tag in it for git-versioning to work.  Recommended solution: git tag v0.0")
 	}
 
 	private fun setProjectVersion(project: Project, versionInfo: VersionInfo) {


### PR DESCRIPTION
This *should* work, but beware that it is possible it will result in a different `git describe` output that breaks the parser.